### PR TITLE
Add ignores for npm and git using Babel

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -57,6 +57,7 @@ module.exports = yeoman.generators.Base.extend({
       this.template('editorconfig', '.editorconfig');
       this.template('gitattributes', '.gitattributes');
       this.template('gitignore', '.gitignore');
+      this.template('npmignore', '.npmignore');
       this.template('eslintrc', '.eslintrc');
       this.template('travis.yml', '.travis.yml');
 

--- a/app/templates/npmignore
+++ b/app/templates/npmignore
@@ -8,8 +8,6 @@ coverage
 .grunt
 .lock-wscript
 build/Release
-node_modules
-npm-debug.log
 <% if (babel) { -%>
-dist
+src/
 <% } -%>


### PR DESCRIPTION
Ignores `src/` in `.npmignore` and `dist/` in `.gitignore`.
