### PR TITLE
Remove babel dependency

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -36,7 +36,6 @@
   "dependencies": {},
   "devDependencies": {
 <% if (babel) { -%>
-    "babel": "*",
     "babel-eslint": "*",
 <% } -%>
     "tape": "*"


### PR DESCRIPTION
Removes Babel from `devDependency` (should be installed globally)
